### PR TITLE
Update `next.config.js` to export statically

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -54,3 +54,7 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
     </Layout>
   )
 }
+
+export function generateStaticParams() {
+	return allBlogs.map((blog) => ({ slug: blog.slug }));
+}

--- a/app/inspiration/[slug]/page.tsx
+++ b/app/inspiration/[slug]/page.tsx
@@ -60,3 +60,7 @@ export default function InspirationPage({
     </Layout>
   )
 }
+
+export function generateStaticParams() {
+	return allInspirations.map((inspiration) => ({ slug: inspiration.slug }));
+}

--- a/app/podcasts/[slug]/page.tsx
+++ b/app/podcasts/[slug]/page.tsx
@@ -82,3 +82,7 @@ export default function PodcastPage({ params }: { params: { slug: string } }) {
     </Layout>
   )
 }
+
+export function generateStaticParams() {
+	return allPodcasts.map((podcast) => ({ slug: podcast.slug }));
+}

--- a/app/resources/[slug]/page.tsx
+++ b/app/resources/[slug]/page.tsx
@@ -80,3 +80,7 @@ export default function ResourcePage({ params }: { params: { slug: string } }) {
     </Layout>
   )
 }
+
+export function generateStaticParams() {
+	return allResources.map((resource) => ({ slug: resource.slug }));
+}

--- a/app/tags/[slug]/page.tsx
+++ b/app/tags/[slug]/page.tsx
@@ -134,3 +134,13 @@ export default function TagPage({ params }: { params: { slug: string } }) {
     </>
   )
 }
+
+export function generateStaticParams() {
+	return [
+    ...allBlogs,
+    ...allInspirations,
+    ...allPodcasts,
+    ...allResources,
+    ...allTools,
+  ].map((post) => post.tags).flat().map((tag) => ({ slug: tag }));
+}

--- a/app/tools/[slug]/page.tsx
+++ b/app/tools/[slug]/page.tsx
@@ -63,3 +63,7 @@ export default function ToolPage({ params }: { params: { slug: string } }) {
     </Layout>
   )
 }
+
+export function generateStaticParams() {
+	return allTools.map((tool) => ({ slug: tool.slug }));
+}

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextconfig = {
   reactStrictMode: true,
   trailingSlash: true,
   output: "standalone",
+  distDir: "build",
   images: {
     loader: "custom",
     imageSizes: [16, 32, 48, 128, 256],

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const { withContentlayer } = require('next-contentlayer2');
 const nextconfig = {
   reactStrictMode: true,
   trailingSlash: true,
-  output: "standalone",
+  output: "export",
   distDir: "build",
   images: {
     loader: "custom",


### PR DESCRIPTION
Update `next.config.js` to export statically:

- Update `next.config.js`'s `distDir` to `build`;
- Update `next.config.js`'s `output` mode to `export`;
- Add `generateStaticParams` function to export statically;

---

- Issue: https://git.chen.so/sveltia-next-ts/i/9b5d83051769e394fe45a004960abe6491893154
- Patch: https://git.chen.so/sveltia-next-ts/p/fa4104cd591fbfe6426e6cb35b76310ce177fc51
- https://github.com/Chen-Software/sveltia-next-ts/pull/5